### PR TITLE
Add iOS version check for addPolyline

### DIFF
--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -1117,27 +1117,31 @@ App.prototype.iOSversion() = function() {
  }
 
 App.prototype.addPolyline = function(polylineOptions, callback) {
-    if(iOSversion()[0] < 11)
+    var iosVersion = iosVersion();
+
+    if(iosVersion !== undefined && iosVersion[0] >= 11)
     {
-        var self = this;
-        polylineOptions.points = polylineOptions.points || [];
-        polylineOptions.color = HTMLColor2RGBA(polylineOptions.color || "#FF000080", 0.75);
-        polylineOptions.width = polylineOptions.width || 10;
-        polylineOptions.visible = polylineOptions.visible === undefined ? true : polylineOptions.visible;
-        polylineOptions.zIndex = polylineOptions.zIndex || 4;
-        polylineOptions.geodesic = polylineOptions.geodesic  === true;
-    
-        cordova.exec(function(result) {
-            var polyline = new Polyline(self, result.id, polylineOptions);
-            OVERLAYS[result.id] = polyline;
-            /*if (typeof polylineOptions.onClick === "function") {
-              polyline.on(plugin.google.maps.event.OVERLAY_CLICK, polylineOptions.onClick);
-            }*/
-            if (typeof callback === "function") {
-                callback.call(self, polyline, self);
-            }
-        }, self.errorHandler, PLUGIN_NAME, 'exec', ['Polyline.createPolyline', self.deleteFromObject(polylineOptions,'function')]);
+        return;
     }
+
+    var self = this;
+    polylineOptions.points = polylineOptions.points || [];
+    polylineOptions.color = HTMLColor2RGBA(polylineOptions.color || "#FF000080", 0.75);
+    polylineOptions.width = polylineOptions.width || 10;
+    polylineOptions.visible = polylineOptions.visible === undefined ? true : polylineOptions.visible;
+    polylineOptions.zIndex = polylineOptions.zIndex || 4;
+    polylineOptions.geodesic = polylineOptions.geodesic  === true;
+
+    cordova.exec(function(result) {
+        var polyline = new Polyline(self, result.id, polylineOptions);
+        OVERLAYS[result.id] = polyline;
+        /*if (typeof polylineOptions.onClick === "function") {
+            polyline.on(plugin.google.maps.event.OVERLAY_CLICK, polylineOptions.onClick);
+        }*/
+        if (typeof callback === "function") {
+            callback.call(self, polyline, self);
+        }
+    }, self.errorHandler, PLUGIN_NAME, 'exec', ['Polyline.createPolyline', self.deleteFromObject(polylineOptions,'function')]);
 };
 //-------------
 // Polygon

--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -1106,25 +1106,38 @@ App.prototype.addCircle = function(circleOptions, callback) {
 //-------------
 // Polyline
 //-------------
-App.prototype.addPolyline = function(polylineOptions, callback) {
-    var self = this;
-    polylineOptions.points = polylineOptions.points || [];
-    polylineOptions.color = HTMLColor2RGBA(polylineOptions.color || "#FF000080", 0.75);
-    polylineOptions.width = polylineOptions.width || 10;
-    polylineOptions.visible = polylineOptions.visible === undefined ? true : polylineOptions.visible;
-    polylineOptions.zIndex = polylineOptions.zIndex || 4;
-    polylineOptions.geodesic = polylineOptions.geodesic  === true;
+// Add check ios version due to a bug in googleMaps sdk(addPolyline crash in iOS11)
+// Should be removed when googleMaps sdk fixed.
+App.prototype.iOSversion() = function() { 
+    if (/iP(hone|od|ad)/.test(navigator.platform)) {
+        var v = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+    
+        return [parseInt(v[1], 10), parseInt(v[2], 10), parseInt(v[3] || 0, 10)];
+    }
+ }
 
-    cordova.exec(function(result) {
-        var polyline = new Polyline(self, result.id, polylineOptions);
-        OVERLAYS[result.id] = polyline;
-        /*if (typeof polylineOptions.onClick === "function") {
-          polyline.on(plugin.google.maps.event.OVERLAY_CLICK, polylineOptions.onClick);
-        }*/
-        if (typeof callback === "function") {
-            callback.call(self, polyline, self);
-        }
-    }, self.errorHandler, PLUGIN_NAME, 'exec', ['Polyline.createPolyline', self.deleteFromObject(polylineOptions,'function')]);
+App.prototype.addPolyline = function(polylineOptions, callback) {
+    if(iOSversion()[0] < 11)
+    {
+        var self = this;
+        polylineOptions.points = polylineOptions.points || [];
+        polylineOptions.color = HTMLColor2RGBA(polylineOptions.color || "#FF000080", 0.75);
+        polylineOptions.width = polylineOptions.width || 10;
+        polylineOptions.visible = polylineOptions.visible === undefined ? true : polylineOptions.visible;
+        polylineOptions.zIndex = polylineOptions.zIndex || 4;
+        polylineOptions.geodesic = polylineOptions.geodesic  === true;
+    
+        cordova.exec(function(result) {
+            var polyline = new Polyline(self, result.id, polylineOptions);
+            OVERLAYS[result.id] = polyline;
+            /*if (typeof polylineOptions.onClick === "function") {
+              polyline.on(plugin.google.maps.event.OVERLAY_CLICK, polylineOptions.onClick);
+            }*/
+            if (typeof callback === "function") {
+                callback.call(self, polyline, self);
+            }
+        }, self.errorHandler, PLUGIN_NAME, 'exec', ['Polyline.createPolyline', self.deleteFromObject(polylineOptions,'function')]);
+    }
 };
 //-------------
 // Polygon


### PR DESCRIPTION
We encountered a bug recently: The application crushes while entering the address in kilometric charge's expense in iOS 11. In xCode log, we got an error message: `Polyline, undeclared selector...`
After the investigation, we conclude that this comes from the googlemaps sdk. We could do nothing but wait for Google fixing it.
In order to ensure the basic use of Cleemy, we figuer out a workaround: we check iOS version before calling "addPolyline". If is in iOS 11, this function won't be call to avoid the initialization of the plugin. This implies the dysfunction of direction drawing in iOS 11, but we got all other essential elements. 
