### PR TITLE
Update dependency repo url because the old one died

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -206,6 +206,6 @@
           </array>
         </config-file>
 
-        <dependency id="com.googlemaps.ios" url="https://bitbucket.org/nightstomp/cordova-plugin-googlemaps-sdk.git" commit="master" />
+        <dependency id="com.googlemaps.ios" url="https://github.com/helixhuang/cordova-plugin-googlemaps-sdk.git" commit="master" />
     </platform>
 </plugin>


### PR DESCRIPTION
The iOS Google Maps SDK was hosted on a bitbucket repo that suddenly died. I found this one to be more reliable.

Careful, this one needs https://git-lfs.github.com/ to be installed as a big file will be downloaded